### PR TITLE
Testing insertEvents message JSON Schema validation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,8 @@ repositories {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation(kotlin("reflect"))
+    implementation("com.networknt:json-schema-validator:1.0.38");
+    implementation("org.json:json:20171018")
     testImplementation("junit:junit:4.13")
 }
 

--- a/src/main/kotlin/org/ionproject/sketches/writeApi/insertEvents.kt
+++ b/src/main/kotlin/org/ionproject/sketches/writeApi/insertEvents.kt
@@ -1,0 +1,52 @@
+package org.ionproject.sketches.writeApi
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.networknt.schema.JsonSchema
+import com.networknt.schema.JsonSchemaFactory
+import com.networknt.schema.SpecVersion
+
+data class HttpRequest(
+  val payload: String,
+  val headers: Map<String, String> = mapOf()
+)
+
+class HttpResponse(
+  val payload: String,
+  val status: Int,
+  val headers: Map<String, String> = mapOf()) {
+
+  override fun toString(): String {
+    return """Status: $status
+Headers: ${headers.entries}
+
+Payload:
+${payload.prependIndent("\t")}
+"""
+  }
+}
+
+/**
+ * Retrieves ValidationMessage from Schema->JSON validation.
+ * @return true - if JSON is a valid object for the Schema
+ */
+fun validate_json(schema: JsonSchema, json: String): List<String> {
+  val node = ObjectMapper()
+    .readTree(json)
+
+  return schema
+    .validate(node)
+    .map { it.message }
+}
+
+fun http_insert_events(req: HttpRequest): HttpResponse {
+  val schema = JsonSchemaFactory
+    .getInstance(SpecVersion.VersionFlag.V201909)
+    .getSchema(insert_events_req_schema)
+
+  val messages = validate_json(schema, req.payload)
+  if (messages.isEmpty()) {
+    return HttpResponse("OK", 200)
+  }
+  return HttpResponse(messages.reduceRight { s, acc -> acc + "\n" + s }, 400)
+}
+

--- a/src/main/kotlin/org/ionproject/sketches/writeApi/json.kt
+++ b/src/main/kotlin/org/ionproject/sketches/writeApi/json.kt
@@ -1,0 +1,185 @@
+package org.ionproject.sketches.writeApi
+
+const val invalid_insert_events_req_json = """
+{
+    "school": {
+        "name": "INSTITUTO SUPERIOR DE ENGENHARIA DE LISBOA",
+        "acr": "ISEL",
+        "additionalProperties": 1
+    },
+    "programme": {
+    },
+    "calendarTerm": "1718v",
+    "calendarSection": "LI11D",
+    "courses": [
+        {
+            "acr": "ALGA[I]",
+            "events": [
+                {
+                    "description": "This event is lacking the title property",
+                    "location": [ "E.1.31" ],
+                    "beginTime": "14:00:00",
+                    "duration": "1:30:00",
+                    "weekday": [ "MO" ]
+                }
+            ]
+        },
+        {
+            "label": {
+              "acr": "M2[I]",
+              "name": "Matemática II"
+            },
+            "events": [
+                {
+                    "title": "Aula de M2",
+                    "location": [ "G.2.30" ],
+                    "beginTime": "14:00:00",
+                    "duration": "1:30:00",
+                    "weekday": [ "TU" ]
+                },
+                {
+                    "title": "Aula de M2",
+                    "location": "G.2.30",
+                    "beginTime": "14:00:00",
+                    "duration": "1:30:00",
+                    "weekday": [ "FR" ]
+                }
+            ]
+        }
+    ]
+}
+  """
+
+const val valid_insert_events_req_json = """
+{
+    "school": {
+        "name": "INSTITUTO SUPERIOR DE ENGENHARIA DE LISBOA",
+        "acr": "ISEL"
+    },
+    "programme": {
+        "name": "Licenciatura Engenharia Informática e Computadores"
+    },
+    "calendarTerm": "1718v",
+    "calendarSection": "LI11D",
+    "courses": [
+        {
+            "label": {
+              "acr": "ALGA[I]"
+            },
+            "events": [
+                {
+                    "title": "Aula de ALGA",
+                    "description": "Aulas teoricas de ALGA",
+                    "location": [ "E.1.31" ],
+                    "beginTime": "14:00:00",
+                    "duration": "1:30:00",
+                    "weekday": [ "MO" ]
+                }
+            ]
+        },
+        {
+            "label": {
+              "acr": "M2[I]",
+              "name": "Matemática II"
+            },
+            "events": [
+                {
+                    "title": "Aula de M2",
+                    "location": [ "G.2.30" ],
+                    "beginTime": "14:00:00",
+                    "duration": "1:30:00",
+                    "weekday": [ "TU" ]
+                },
+                {
+                    "title": "Aula de M2",
+                    "location": [ "G.2.30" ],
+                    "beginTime": "14:00:00",
+                    "duration": "1:30:00",
+                    "weekday": [ "FR" ]
+                }
+            ]
+        }
+    ]
+}
+  """
+
+const val insert_events_req_schema =
+  """
+    {
+  "definitions": {
+    "academicObject": {
+      "${'$'}id": "#academicObject",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 50
+        },
+        "acr": {
+          "type": "string",
+          "minLength": 2,
+          "maxLength": 10
+        }
+      },
+      "anyOf": [
+        { "required": [ "name" ] },
+        { "required": [ "acr" ] }
+      ],
+      "additionalProperties": false
+    },
+
+    "event": {
+      "${'$'}id": "#event",
+      "type": "object",
+      "properties": {
+        "title": { "type": "string" },
+        "description": { "type": "string" },
+        "location": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "beginTime": { "type": "string" },
+        "duration": { "type": "string" },
+        "weekday": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [ "MO", "TU", "WE", "TH", "FR", "SA", "SU" ]
+          }
+        }
+      },
+      "required": [ "title", "beginTime", "duration" ],
+      "additionalProperties": false
+    },
+
+    "course": {
+      "${'$'}id": "#course",
+      "properties": {
+        "label": { "${'$'}ref": "#academicObject" },
+        "events": {
+          "type": "array",
+          "items": { "${'$'}ref": "#event" }
+        }
+      },
+      "required": [ "label", "events" ],
+      "additionalProperties": false
+    }
+  },
+
+  "${'$'}id": "#root",
+  "type": "object",
+  "properties": {
+    "school": { "${'$'}ref": "#academicObject" },
+    "programme": { "${'$'}ref": "#academicObject" },
+    "calendarSection": { "type": "string" },
+    "calendarTerm": { "type": "string" },
+    "courses": {
+      "type": "array",
+      "items": { "${'$'}ref": "#course" }
+    }
+  },
+  "required": [ "school", "programme", "courses", "calendarTerm" ],
+  "additionalProperties": false
+} 
+"""

--- a/src/test/kotlin/org/ionproject/sketches/writeApi/InsertEventsTest.kt
+++ b/src/test/kotlin/org/ionproject/sketches/writeApi/InsertEventsTest.kt
@@ -1,0 +1,26 @@
+package org.ionproject.sketches.writeApi
+
+import junit.framework.Assert.*
+import org.junit.Test
+
+class InsertEventsTest {
+
+  @Test
+  fun valid_request() {
+    val req = HttpRequest(valid_insert_events_req_json)
+    val resp = http_insert_events(req)
+    println("Valid request: $resp")
+
+    assertEquals(200, resp.status)
+  }
+
+  @Test
+  fun invalid_request() {
+    val req = HttpRequest(invalid_insert_events_req_json)
+    val resp = http_insert_events(req)
+    println("Invalid request: $resp")
+
+    assertEquals(400, resp.status)
+  }
+
+}


### PR DESCRIPTION
Uses [this library](https://github.com/networknt/json-schema-validator) to validade the incoming requests with a given JSON Schema.
The JSON schema and request examples used will be thoroughly documented [here](https://github.com/i-on-project/core/pull/124).